### PR TITLE
feat: add web chat streaming app

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_api_key_here

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,34 @@
+# Web App
+
+Minimal Express server providing a `/api/chat` endpoint that streams responses from OpenAI.
+
+## Setup
+
+1. Install dependencies
+
+   ```bash
+   npm install
+   ```
+
+2. Copy the environment file and set your OpenAI API key
+
+   ```bash
+   cp apps/web/.env.example apps/web/.env
+   # edit apps/web/.env and set OPENAI_API_KEY
+   ```
+
+3. Start the server
+
+   ```bash
+   npm start --workspace apps/web
+   ```
+
+4. Send a chat request
+
+   ```bash
+   curl -X POST http://localhost:3000/api/chat \
+     -H "Content-Type: application/json" \
+     -d '{"messages":[{"role":"user","content":"Hello"}]}'
+   ```
+
+Tokens are streamed back in the response. Each request logs the OpenAI `requestId`.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js",
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "openai": "^4.52.0"
+  }
+}

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -1,0 +1,40 @@
+import express from "express";
+import OpenAI from "openai";
+
+const app = express();
+app.use(express.json());
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+app.post("/api/chat", async (req, res) => {
+  const { messages } = req.body;
+  if (!Array.isArray(messages)) {
+    return res.status(400).json({ error: "messages must be an array" });
+  }
+
+  try {
+    const stream = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages,
+      stream: true,
+    });
+
+    console.log("requestId:", stream.requestId);
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.setHeader("Transfer-Encoding", "chunked");
+
+    for await (const part of stream) {
+      const token = part.choices[0]?.delta?.content || "";
+      res.write(token);
+    }
+    res.end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "An error occurred" });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- scaffold minimal Express workspace at apps/web
- stream chat completions from OpenAI via POST /api/chat
- add README and environment example for quick setup

## Testing
- `npm install --workspace apps/web --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test --workspace apps/web`
- `node apps/web/server.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a00af674888333ad66b5e4d62ca967